### PR TITLE
feat: write to any storage slot

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,5 +4,7 @@
 
   - [Variables](./variables/variables.md)
 
+  - [Write to Any Slot](./introduction/write_to_any_slot/write_to_any_slot.md)
+
 - [Applications](./applications/applications.md)
   - [Upgradeable Contract](./applications/upgradeable_contract/upgradeable_contract.md)

--- a/src/introduction/write_to_any_slot/test_write_any_slot.cairo
+++ b/src/introduction/write_to_any_slot/test_write_any_slot.cairo
@@ -1,0 +1,83 @@
+#[abi]
+trait IWriteToAnySlot {
+    fn write_slot(value: u32);
+    fn read_slot() -> u32;
+}
+
+
+#[contract]
+mod WriteToAnySlot {
+    use keccak::keccak_uint256s_le;
+    use keccak::keccak_uint256s_be;
+    use starknet::syscalls::{storage_read_syscall, storage_write_syscall};
+    use array::ArrayTrait;
+    use option::OptionTrait;
+    use traits::{Into, TryInto};
+    use poseidon::poseidon_hash_span;
+    use starknet::StorageAddress;
+    use starknet::storage_access::Felt252TryIntoStorageAddress;
+
+    struct Storage {
+        test_slot: u32
+    }
+
+    const SLOT_NAME: felt252 = 'test_slot';
+
+    #[external]
+    fn write_slot(value: u32) {
+        storage_write_syscall(0, get_address_from_name(SLOT_NAME), value.into());
+    }
+
+    #[view]
+    fn read_slot() -> u32 {
+        storage_read_syscall(0, get_address_from_name(SLOT_NAME))
+            .unwrap_syscall()
+            .try_into()
+            .unwrap()
+    }
+
+    fn get_address_from_name(variable_name: felt252) -> StorageAddress {
+        let mut data: Array<felt252> = ArrayTrait::new();
+        data.append(variable_name);
+        let hashed_name: felt252 = poseidon_hash_span(data.span());
+        let MASK_250: u256 = 0x03ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+        // By taking the 250 least significant bits of the hash output, we get a valid 250bits storage address.
+        let result: felt252 = (hashed_name.into() & MASK_250).try_into().unwrap();
+        let result: StorageAddress = result.try_into().unwrap();
+        result
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::WriteToAnySlot::{get_address_from_name};
+    use super::WriteToAnySlot;
+    use super::{IWriteToAnySlotDispatcher, IWriteToAnySlotDispatcherTrait};
+    use debug::PrintTrait;
+    use starknet::deploy_syscall;
+    use option::OptionTrait;
+    use array::ArrayTrait;
+    use traits::{Into, TryInto};
+    use starknet::class_hash::Felt252TryIntoClassHash;
+    use result::ResultTrait;
+
+    #[test]
+    #[available_gas(2000000000)]
+    fn test_read_write() {
+        // Set up.
+        let mut calldata: Array<felt252> = ArrayTrait::new();
+        let (address0, _) = deploy_syscall(
+            WriteToAnySlot::TEST_CLASS_HASH.try_into().unwrap(), 0, calldata.span(), false
+        )
+            .unwrap();
+        let mut contract = IWriteToAnySlotDispatcher { contract_address: address0 };
+
+        // Write to slot.
+        let value: u32 = 42;
+        contract.write_slot(value);
+
+        // Read from slot.
+        let read_value = contract.read_slot();
+        assert(read_value == value, 'wrong value read');
+    }
+}
+

--- a/src/introduction/write_to_any_slot/test_write_any_slot.cairo
+++ b/src/introduction/write_to_any_slot/test_write_any_slot.cairo
@@ -4,22 +4,16 @@ trait IWriteToAnySlot {
     fn read_slot() -> u32;
 }
 
-
 #[contract]
 mod WriteToAnySlot {
-    use keccak::keccak_uint256s_le;
-    use keccak::keccak_uint256s_be;
     use starknet::syscalls::{storage_read_syscall, storage_write_syscall};
     use array::ArrayTrait;
     use option::OptionTrait;
     use traits::{Into, TryInto};
     use poseidon::poseidon_hash_span;
-    use starknet::StorageAddress;
     use starknet::storage_access::Felt252TryIntoStorageAddress;
 
-    struct Storage {
-        test_slot: u32
-    }
+    struct Storage {}
 
     const SLOT_NAME: felt252 = 'test_slot';
 
@@ -47,6 +41,7 @@ mod WriteToAnySlot {
         result
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::WriteToAnySlot::{get_address_from_name};

--- a/src/introduction/write_to_any_slot/write_any_slot.cairo
+++ b/src/introduction/write_to_any_slot/write_any_slot.cairo
@@ -5,12 +5,9 @@ mod WriteToAnySlot {
     use option::OptionTrait;
     use traits::{Into, TryInto};
     use poseidon::poseidon_hash_span;
-    use starknet::StorageAddress;
     use starknet::storage_access::Felt252TryIntoStorageAddress;
 
-    struct Storage {
-        test_slot: u32
-    }
+    struct Storage {}
 
     const SLOT_NAME: felt252 = 'test_slot';
 

--- a/src/introduction/write_to_any_slot/write_any_slot.cairo
+++ b/src/introduction/write_to_any_slot/write_any_slot.cairo
@@ -1,0 +1,40 @@
+#[contract]
+mod WriteToAnySlot {
+    use starknet::syscalls::{storage_read_syscall, storage_write_syscall};
+    use array::ArrayTrait;
+    use option::OptionTrait;
+    use traits::{Into, TryInto};
+    use poseidon::poseidon_hash_span;
+    use starknet::StorageAddress;
+    use starknet::storage_access::Felt252TryIntoStorageAddress;
+
+    struct Storage {
+        test_slot: u32
+    }
+
+    const SLOT_NAME: felt252 = 'test_slot';
+
+    #[external]
+    fn write_slot(value: u32) {
+        storage_write_syscall(0, get_address_from_name(SLOT_NAME), value.into());
+    }
+
+    #[view]
+    fn read_slot() -> u32 {
+        storage_read_syscall(0, get_address_from_name(SLOT_NAME))
+            .unwrap_syscall()
+            .try_into()
+            .unwrap()
+    }
+
+    fn get_address_from_name(variable_name: felt252) -> StorageAddress {
+        let mut data: Array<felt252> = ArrayTrait::new();
+        data.append(variable_name);
+        let hashed_name: felt252 = poseidon_hash_span(data.span());
+        let MASK_250: u256 = 0x03ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+        // By taking the 250 least significant bits of the hash output, we get a valid 250bits storage address.
+        let result: felt252 = (hashed_name.into() & MASK_250).try_into().unwrap();
+        let result: StorageAddress = result.try_into().unwrap();
+        result
+    }
+}

--- a/src/introduction/write_to_any_slot/write_to_any_slot.md
+++ b/src/introduction/write_to_any_slot/write_to_any_slot.md
@@ -1,0 +1,15 @@
+# Write to Any Slot
+
+On Starknet, a contract's storage is a map with 2^251 slots, where each slot is a felt which is initialized to 0.
+The address of storage variables is computed at compile time using the formula: `storage variable address := pedersen(keccak(variable name), keys)`. Interactions with storage variables are commonly performed using the `var::read()` and `var::write()` functions.
+
+<!-- TODO Update the previous paragraph after 1.2.0 release -->
+
+Nevertheless, we can use the `storage_write_syscall` and `storage_read_syscall` syscalls, to write to and read from any storage slot.
+This is useful when writing to storage variables that are not known at compile time, or to ensure that even if the contract is upgraded and the computation method of storage variable address changes, they remain accessible.
+
+In the following example, we use the Poseidon hash function to compute the address of a storage variable. Poseidon is a ZK-friendly hash function that is cheaper and faster than Pedersen, making it an excellent choice for onchain computations.
+
+```rust
+{{#include write_any_slot.cairo}}
+```

--- a/src/introduction/write_to_any_slot/write_to_any_slot.md
+++ b/src/introduction/write_to_any_slot/write_to_any_slot.md
@@ -6,9 +6,9 @@ The address of storage variables is computed at compile time using the formula: 
 <!-- TODO Update the previous paragraph after 1.2.0 release -->
 
 Nevertheless, we can use the `storage_write_syscall` and `storage_read_syscall` syscalls, to write to and read from any storage slot.
-This is useful when writing to storage variables that are not known at compile time, or to ensure that even if the contract is upgraded and the computation method of storage variable address changes, they remain accessible.
+This is useful when writing to storage variables that are not known at compile time, or to ensure that even if the contract is upgraded and the computation method of storage variable addresses changes, they remain accessible.
 
-In the following example, we use the Poseidon hash function to compute the address of a storage variable. Poseidon is a ZK-friendly hash function that is cheaper and faster than Pedersen, making it an excellent choice for onchain computations.
+In the following example, we use the Poseidon hash function to compute the address of a storage variable. Poseidon is a ZK-friendly hash function that is cheaper and faster than Pedersen, making it an excellent choice for onchain computations. Once the address is computed, we use the storage syscalls to interact with it.
 
 ```rust
 {{#include write_any_slot.cairo}}


### PR DESCRIPTION
Closes #17 
In this example, we demonstrate how we can compute storage addresses onchain with the poseidon hash function, and write to any slot with storage syscalls.

@swapnilraj are there any security issues to consider with this implementation? I think that the output of poseidon is a felt252 so I restricted addresses sizes to 250 bits.

I believe that in the future storage addresses will be computed with Poseidon, so it makes even more sense to use it here.
From there, can use this contract to demonstrate how to create an EternalStorage contract.